### PR TITLE
fix: remove flag check for read

### DIFF
--- a/reversion/version_file.py
+++ b/reversion/version_file.py
@@ -19,9 +19,6 @@ def get_file_path(pk):
 
 
 def read(pk):
-    if not ARCHIVE_ENABLED:
-        return
-
     file = get_file_path(pk)
     if file.exists():
         compressed = file.read_bytes()


### PR DESCRIPTION
This fixes an issue where Versions with `is_archived` set to True will return an empty `serialized_data` field when retrieved from db if `VERSION_ARCHIVE_ENABLED` is set to False.